### PR TITLE
deprecated function and html adjustment

### DIFF
--- a/gocart/helpers/credit_card_helper.php
+++ b/gocart/helpers/credit_card_helper.php
@@ -81,7 +81,7 @@ function card_expiry_valid($month, $year) {
 * @return string The stripped down card number.
 */
 function card_number_clean($number) {
-    return ereg_replace("[^0-9]", "", $number);
+    return preg_replace("[^0-9]", "", $number);
 }
 
 

--- a/gocart/views/header.php
+++ b/gocart/views/header.php
@@ -137,7 +137,7 @@ if(isset($additional_header_info))
 			}
 			?>
 			</a>
-		<li>
+		</li>
 			
 		</ul>
 	</div>


### PR DESCRIPTION
The ereg_replace function used in the credit card helper generates a warning as it has been deprecated in favor of preg_replace.
http://us.php.net/manual/en/function.ereg-replace.php

Also, there is a li tag not properly closed in the header, so I closed the tag
