### PR TITLE
1.2

### DIFF
--- a/gocart/controllers/admin/products.php
+++ b/gocart/controllers/admin/products.php
@@ -419,6 +419,30 @@ class Products extends Admin_Controller {
 				//if the product is legit, delete them
 				$this->Product_model->delete_product($id);
 
+				/* my fix 002
+				 * 
+				 * delete images of product or the files will remain undeleted forever and mixed with correctly associated to product or category files
+				 * 
+				 */
+				$images = json_decode($product->images);
+				
+				foreach($images as $image) {
+					$file = array();
+					$file[] = 'uploads/images/full/'.$image->filename;
+					$file[] = 'uploads/images/medium/'.$image->filename;
+					$file[] = 'uploads/images/small/'.$image->filename;
+					$file[] = 'uploads/images/thumbnails/'.$image->filename;
+					
+					foreach($file as $f)
+					{
+						//delete the existing file if needed
+						if(file_exists($f))
+						{
+							unlink($f);
+						}
+					}
+				}
+
 				$this->session->set_flashdata('message', lang('message_deleted_product'));
 				redirect($this->config->item('admin_folder').'/products');
 			}

--- a/gocart/models/category_model.php
+++ b/gocart/models/category_model.php
@@ -116,6 +116,19 @@ Class Category_model extends CI_Model
 		$this->db->where('id', $id);
 		$this->db->delete('categories');
 		
+		/* my fix 004.1
+		 * 
+		 * delete all category children of this category or nobody will never remove them from database.
+		 * this can be a cascade process so we use recursive call of this delete function.
+		 * the image file of each category must be deleted samewhere else. It's not correct to unlink files in model.
+		 * 
+		 * */
+		$category_children = $this->get_categories($id);
+		
+		foreach ($category_children as $category_child) {
+			$this->delete($category_child->id);
+		}
+		
 		//delete references to this category in the product to category table
 		$this->db->where('category_id', $id);
 		$this->db->delete('category_products');

--- a/gocart/themes/default/views/checkout/customer_details_static.php
+++ b/gocart/themes/default/views/checkout/customer_details_static.php
@@ -8,8 +8,28 @@ $.post('<?php echo site_url('checkout/shipping_payment_methods');?>', function(d
 });
 </script>
 <?php
+/* old code
+ * 
+ * when you set the first address if make it as ship but not bill an error is displayed.
+
 $bill	= $customer['bill_address'];
 $ship	= $customer['ship_address'];
+*/
+
+/* my fix 001
+ * 
+ * this fix assume that bill address, if not setted, is always the same as shipping
+ * 
+ * */
+$ship	= $customer['ship_address'];
+
+if (isset($customer['bill_address'])) {
+	$bill	= $customer['bill_address'];
+}
+else {
+	$bill	= $customer['ship_address'];
+}
+
 ?>
 
 <div id="shipping_address">


### PR DESCRIPTION
Same fix and improvement i realized using GoCart:

my fix 001:

before fix: if you enter the first address for a given user and you mark it only as shipping when checking out billing address generate error.

after fix: we assume billing equal to shipping if billing address is not set.

my fix 002:

before fix: when admin delete a product all its image files remain on file system. It's very hard to determinate what files are still linked with a product or not.

after fix: deleting a product unlink all image files linked to that product

my fix 003.1/003.2:

this bugfix is connected with bug fix 004 since recursively removing category needs to recursively remove image files of category

before fix: when admin delete a category the image file remains on file system. It's very hard to determinate what files are still linked with a category or not.

after fix: deleting a category unlink the image file linked to that category

my fix 004:

before fix: when removing a category parent of other category, all children was orphaned in database and not more visible or usable

after fix: when removing a category now we walk through all children and remove all hierarchy
