### PR TITLE
Issue 75 : compute tax for whole order coupon

### DIFF
--- a/gocart/libraries/Go_cart.php
+++ b/gocart/libraries/Go_cart.php
@@ -525,7 +525,7 @@ class go_cart {
 					// store the total discount in the item details, for future reference
 					$this->_cart_contents['items'][$product_index[$x]]['total_coupon_discount'] += $collapsed[$x];
 					// taxable?
-					if( $this->_cart_contents['items'][$product_index[$x]]['shippable'] == 1 )
+					if( $this->_cart_contents['items'][$product_index[$x]]['taxable'] == 1 )
 					{
 						$taxable_discount +=  $collapsed[$x];
 					}

--- a/gocart/libraries/Go_cart.php
+++ b/gocart/libraries/Go_cart.php
@@ -556,9 +556,19 @@ class go_cart {
 					$this->_cart_contents['whole_order_discount_cp'] = $code; // track which code we use
 				}
 			}
-			$total_discount = $temp;
-		}
-		
+            // coupon discounts and whole order discounts can be cumulated
+			$total_discount += $temp;
+            $total_whole_order_discount = $temp;
+
+            // iterate products and apply calculated whole order discount % to taxable ones
+            $whole_order_discount_ratio = $total_whole_order_discount / (float)$this->_cart_contents['cart_subtotal'];
+            foreach ($this->_cart_contents['items'] as $product){
+                if ($product['taxable'] == 1){
+                    $taxable_discount += $whole_order_discount_ratio * (float)$product['price'];
+                }
+            }
+
+		}		
 		
 		$this->_cart_contents['cp_discounted_subtotal'] = $this->_cart_contents['cart_subtotal'] - $total_discount;
 		$this->_cart_contents['coupon_discount'] = $total_discount;

--- a/gocart/libraries/Go_cart.php
+++ b/gocart/libraries/Go_cart.php
@@ -561,10 +561,12 @@ class go_cart {
             $total_whole_order_discount = $temp;
 
             // iterate products and apply calculated whole order discount % to taxable ones
-            $whole_order_discount_ratio = $total_whole_order_discount / (float)$this->_cart_contents['cart_subtotal'];
-            foreach ($this->_cart_contents['items'] as $product){
-                if ($product['taxable'] == 1){
-                    $taxable_discount += $whole_order_discount_ratio * (float)$product['price'];
+            if ($this->_cart_contents['cart_subtotal'] > 0){
+                $whole_order_discount_ratio = $total_whole_order_discount / (float)$this->_cart_contents['cart_subtotal'];
+                foreach ($this->_cart_contents['items'] as $product){
+                    if ($product['taxable'] == 1){
+                        $taxable_discount += $whole_order_discount_ratio * (float)$product['price'] * (int)$product['quantity'];
+                    }
                 }
             }
 


### PR DESCRIPTION
I think I got this one, for issue #75.

Found one additional bug when hunting the original one down : [fix on this commit](https://github.com/abulte/GoCart/commit/17c19ae090e6aa987a7588052aef20bbc1d19e70) 

I made the (essential) assumption that you can cumulate a whole order coupon with a product coupon.

You can see a result of my tests here : http://cl.ly/image/1J1W3M1b222L . Tested with : 
- both taxable and non taxable products
- whole order coupon (5%)
- product coupon on the taxable one (5%)

Hope this helps.

(I messed up in my commit messages, sorry. It's issue #75, not #71)
