### PR TITLE
Make the error checking language independent

### DIFF
--- a/gocart/controllers/admin/categories.php
+++ b/gocart/controllers/admin/categories.php
@@ -195,7 +195,7 @@ class Categories extends Admin_Controller {
 			if(!$uploaded)
 			{
 				$error	= $this->upload->display_errors();
-				if($error != lang('error_file_upload'))
+				if($this->input->post('image')!=false)
 				{
 					$data['error']	.= $this->upload->display_errors();
 					$this->load->view($this->config->item('admin_folder').'/category_form', $data);


### PR DESCRIPTION
Isn't it prettier to check if the image post is empty instead of checking an error message here?
