### PR TITLE
Return false if payment fails

### DIFF
--- a/gocart/controllers/checkout.php
+++ b/gocart/controllers/checkout.php
@@ -439,6 +439,7 @@ class Checkout extends Front_Controller {
 		else
 		{
 			$this->form_validation->set_message('check_payment', $check);
+			return false;
 		}
 	}
 


### PR DESCRIPTION
If a payment package failed and returned an error, it just ignored it and continued on. This makes it display the errors.
