### PR TITLE
Fix for Safari

### DIFF
--- a/gocart/themes/default/views/address_form.php
+++ b/gocart/themes/default/views/address_form.php
@@ -96,7 +96,7 @@ $(function(){
 
 function save_address()
 {
-	$.post("<?php echo site_url('secure/address_form');?>/"+$('#f_id').val(), {	company: $('#f_company').val(),
+	$.post("<?php echo site_url('secure/address_form');?>"+($('#f_id').val() ? '/'+$('#f_id').val() : ''), {	company: $('#f_company').val(),
 																				firstname: $('#f_firstname').val(),
 																				lastname: $('#f_lastname').val(),
 																				email: $('#f_email').val(),


### PR DESCRIPTION
When creating a new address (ie, `$('#f_id').val()` is blank) Safari seems to redirect from `secure/address_form/` to `secure/address_form` which causes the form to fail to validate, and doesn't show any validation errors.
